### PR TITLE
upload-content: Upload large content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-prediktor-config-repo",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "A collection of nodes to communicate with Prediktor Configuration Repository",
     "main": "src/main.js",
     "repository": {

--- a/src/nodes/upload-content.html
+++ b/src/nodes/upload-content.html
@@ -6,7 +6,8 @@
             name: {value: ""},
             server: {value: "", type: "prediktor-config-repository"},
             nodeId: {value: ""},
-            contentType: {value: "binary"}
+            fileName: {value: ""},
+            contentType: {value: "Text"}
         },
         inputs:1,
         outputs:1,
@@ -23,8 +24,8 @@
         <input type="text" id="node-input-server" placeholder="Server URL (ex. localhost:5001)">
     </div>
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-input-name" placeholder="Name">
+        <label for="node-input-fileName"><i class="fa fa-tag"></i> File name</label>
+        <input type="text" id="node-input-fileName" placeholder="Path and name of file">
     </div>
     <div class="form-row">
         <label for="node-input-nodeId"><i class="fa fa-tag"></i> Node Id</label>
@@ -40,12 +41,12 @@
 </script>
 
 <script type="text/html" data-help-name="upload-content">
-    <p>Upload binary or text content to a predefined node in Config Repository</p>
+    <p>Upload binary or text content to a predefined revision in Config Repository</p>
     <h3>Details</h3>
     <b>Allowed input</b>
     <ul>
-      <li><code>msg.nodeId</code> The Id of the Revision you want to upload to</li>
-      <li><code>msg.data</code> The actual content</li>
+      <li><code>msg.nodeId</code> The Id of the Revision you want to upload to. Will use configured value if not empty</li>
+      <li><code>msg.fileName</code> Path and name of file. Will use configured value if not empty</li>      
     </ul>
     <p>
         Select the type of content to upload from the dropdown. It is a part of the node config, and can not be changed by the msg.

--- a/src/nodes/upload-content.js
+++ b/src/nodes/upload-content.js
@@ -18,7 +18,8 @@ module.exports = function(RED) {
             const data_len = data.length;
             var i = 0;
             while(i < data_len){
-                chunk = data.slice(i, i += data_len)
+                let toIndex = Math.min(data_len - i, chunk_size);
+                let chunk = data.slice(i, i += toIndex)
                 if(config.contentType == "Binary")
                     chunks.push({ binaryChunk: { bytes: chunk } });
                 else

--- a/src/nodes/upload-content.js
+++ b/src/nodes/upload-content.js
@@ -1,57 +1,82 @@
+const { loadPackageDefinition } = require('@grpc/grpc-js');
 let utils = require('../utils/grpc');
+let fs = require('fs');
+
 module.exports = function(RED) {
     function uploadContentNode(config) {
         RED.nodes.createNode(this, config);
-        var node = this;
+        const node = this;
         this.server = RED.nodes.getNode(config.server);
 
         node.on('input', function(msg) {
-            var data;
-            data = msg.data
-            const nodeId = msg.nodeId || config.nodeId;
 
-            var chunks = [
-                {  revisionId: { id: nodeId } },
-            ];
+            uploadContent(msg);
+        });
 
-            const chunk_size = 4000000; // 4 MB
-            const data_len = data.length;
-            var i = 0;
-            while(i < data_len){
-                let toIndex = Math.min(data_len - i, chunk_size);
-                let chunk = data.slice(i, i += toIndex)
-                if(config.contentType == "Binary")
-                    chunks.push({ binaryChunk: { bytes: chunk } });
-                else
-                    chunks.push({  textChunk: { arr: [chunk] } });
+        function uploadContent(msg) {
+
+            const nodeId = config.nodeId || msg.nodeId;
+            const fileName = config.fileName || msg.fileName;
+
+            if(!nodeId) {
+                msg.error = 'No nodeId specified. Upload content failed';
+                node.send(msg);
+                return;
             }
 
-            const method = (config.contentType == "Binary") ? "uploadBinaryContent" : "uploadTextContent";
+            if(!fileName) {
+                msg.error = 'No fileName specified. Upload content failed';
+                node.send(msg);
+                return;
+            }
+
+            if(!fs.existsSync(fileName)) {
+                msg.error = 'File \'' + fileName + '\' was not found';
+                node.send(msg);
+                return;
+            }
+
+            const method = config.contentType == "Binary" ? "uploadBinaryContent" : "uploadTextContent";
             const url = node.server.host+":"+node.server.port;
             const client = utils.getClient(url);
 
-            function runUploadChunk(callback){
-                var call = client[method](function(err, data) {
+            function runUploadInChunks() {
+                const call = client[method](function(err, data) {
                     msg.payload = data;
 
-                    if(err == null && !data?.success) {
-                        msg.error = data.error;
-                    }
-                    else {
-                        msg.error = err;
-                    }
+                    msg.error = (err == null && !data?.success) ? data.error : err;
     
                     node.send(msg);
                 });
 
-                for(const chunk of chunks){
-                    call.write(chunk);
+                let revChunk = {  revisionId: { id: nodeId } };
+                call.write(revChunk);
+
+                async function streamFile() {
+
+                    const chunk_size = 4000000; // 4 MB
+
+                    let contentType = config.contentType == "Binary" ? null : "utf8";
+
+                    const stream = fs.createReadStream(fileName, 
+                        {highWaterMark: chunk_size, encoding: contentType});
+
+                    for await (const data of stream) {
+                        
+                        let chunk = config.contentType == "Binary" ? {  binaryChunk: { bytes: data } } : {  textChunk: { arr: [data] } };
+
+                        call.write(chunk);
+                    }
+
+                    call.end();
                 }
-                call.end();
+
+                streamFile();
             }
 
-            runUploadChunk();
-        });
+            runUploadInChunks();
+        }
     }
+
     RED.nodes.registerType("upload-content", uploadContentNode);
 }


### PR DESCRIPTION
Reading file content moved into the node upload-content. This enables reading the file as a stream and no need for 3.party nodes for file read. Node now handles files of any size.